### PR TITLE
Feat: add nft metadata

### DIFF
--- a/src/frontend/src/pages/Tag/MetadataInfo.tsx
+++ b/src/frontend/src/pages/Tag/MetadataInfo.tsx
@@ -1,12 +1,15 @@
 import React, { useMemo } from 'react';
 import './styles.Tag.css';
 import { TagExpanded } from '../../utils/types';
+import { getScanUrl } from '../../utils/evm';
 
 const MetadataInfo = (props: { tag: TagExpanded | undefined }) => {
   const { tag } = props;
   const nftDetails = tag?.nftDetails;
   const metadata = tag?.metadata;
   const isNft = useMemo(() => nftDetails, [nftDetails]);
+
+  const scanUri = useMemo(() => getScanUrl(nftDetails), [nftDetails]);
 
   return (
     <div>
@@ -16,12 +19,10 @@ const MetadataInfo = (props: { tag: TagExpanded | undefined }) => {
       <p className="description">{metadata?.description}</p>
       {isNft && (
         <div>
-          <h4>Chain</h4>
-          <p>{nftDetails?.chain}</p>
-          <h4>Address</h4>
-          <p>{nftDetails?.address}</p>
-          <h4>Id</h4>
-          <p>{nftDetails?.id}</p>
+          <h4>NFT</h4>
+          <a href={scanUri} target="_blank">
+            {nftDetails!.chain}:{nftDetails!.address}:{nftDetails!.id}
+          </a>
         </div>
       )}
     </div>

--- a/src/frontend/src/pages/Tag/MetadataInfo.tsx
+++ b/src/frontend/src/pages/Tag/MetadataInfo.tsx
@@ -20,7 +20,7 @@ const MetadataInfo = (props: { tag: TagExpanded | undefined }) => {
       {isNft && (
         <div>
           <h4>NFT</h4>
-          <a href={scanUri} target="_blank">
+          <a href={scanUri} target="_blank" rel="noreferrer">
             {nftDetails!.chain}:{nftDetails!.address}:{nftDetails!.id}
           </a>
         </div>

--- a/src/frontend/src/pages/Verify/Success.tsx
+++ b/src/frontend/src/pages/Verify/Success.tsx
@@ -74,7 +74,7 @@ const Success = (props: {
           {isNft && (
             <div>
               <h4>NFT</h4>
-              <a href={scanUri} target="_blank">
+              <a href={scanUri} target="_blank" rel="noreferrer">
                 {nftDetails!.chain}:{nftDetails!.address}:{nftDetails!.id}
               </a>
             </div>

--- a/src/frontend/src/pages/Verify/Success.tsx
+++ b/src/frontend/src/pages/Verify/Success.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Certificate,
   Frame,
+  NFTDetails,
   NFTMetadata,
 } from '../../declarations/backend/backend.did';
-import { getMetadataFromNft } from '../../utils/evm';
+import { getMetadataFromNft, getScanUrl } from '../../utils/evm';
 import { transformUrl } from '../../utils/transformations';
 
 const Success = (props: {
@@ -14,12 +15,18 @@ const Success = (props: {
   const [isCertificate, setIsCertificate] = useState(false);
   const [metadata, setMetadata] = useState<undefined | NFTMetadata>();
   const [isLoading, setIsLoading] = useState(true);
+  const [nftDetails, setNftDetails] = useState<NFTDetails>();
+  const isNft = useMemo(() => nftDetails, [nftDetails]);
+  const scanUri = useMemo(() => getScanUrl(nftDetails), [nftDetails]);
 
   useEffect(() => {
     if (tagContent) {
       setIsCertificate('Certificate' in tagContent);
       if ('Certificate' in tagContent) {
         setMetadata(tagContent.Certificate.metadata[0]);
+        if (tagContent.Certificate.nft_details.length > 0) {
+          setNftDetails(tagContent.Certificate.nft_details[0]);
+        }
         setIsLoading(false);
       } else {
         if (tagContent.Frame.nft.length === 1) {
@@ -64,6 +71,14 @@ const Success = (props: {
           <p>{metadata?.name}</p>
           <h5>Description</h5>
           <p>{metadata?.description}</p>
+          {isNft && (
+            <div>
+              <h4>NFT</h4>
+              <a href={scanUri} target="_blank">
+                {nftDetails!.chain}:{nftDetails!.address}:{nftDetails!.id}
+              </a>
+            </div>
+          )}
         </div>
       ) : (
         <p>The frame is empty.</p>

--- a/src/frontend/src/utils/evm.ts
+++ b/src/frontend/src/utils/evm.ts
@@ -1,6 +1,11 @@
-import { NFT, NFTMetadata } from '../declarations/backend/backend.did';
+import {
+  NFT,
+  NFTDetails,
+  NFTMetadata,
+} from '../declarations/backend/backend.did';
 import { ethers } from 'ethers';
 import { transformUrl } from './transformations';
+import { SupportedChain } from './types';
 
 enum NftStandard {
   ERC721 = '721',
@@ -117,4 +122,18 @@ export const getMetadataFromNft = async (nft: NFT): Promise<NFTMetadata> => {
   });
   const responseJSON = await response.json();
   return responseJSON as NFTMetadata;
+};
+
+const chainToExplorerMapping: Record<SupportedChain, string> = {
+  eth: 'https://etherscan.io/nft',
+  polygon: 'https://polygonscan.com/nft',
+  base: 'https://basescan.org/nft',
+};
+
+export const getScanUrl = (nftDetails: NFTDetails | undefined) => {
+  if (!nftDetails) {
+    return '';
+  }
+  const { chain, address, id } = nftDetails;
+  return `${chainToExplorerMapping[chain as SupportedChain]}/${address}/${id}`;
 };


### PR DESCRIPTION
**GOAL**

- Add NFT metadata external link to chain explorer

**DONE**

- Added link to external explorer
- Visualize NFT metadata in a more compact way: format is not <chain>:<address>:<id>
- Add NFT metadata to verification page

