### PR TITLE
fix: solve metamask warning

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -50,7 +50,7 @@ dfx deploy --network "$network" -q backend --yes
 dfx deploy --network "$network" -q assets --yes
 dfx deploy --network "$network" -q ic_siwe_provider --yes --argument "( \
      record { \
-         domain = \"aelig.art\"; \
+         domain = \"tag.aelig.art\"; \
          uri = \"https://tag.aelig.art\"; \
          salt = \"$IC_SIWE_PROVIDER_SALT\"; \
          chain_id = opt 1; \


### PR DESCRIPTION
**GOAL**

- Fix Metamask warning

**DONE**

- use 'tag.aelig.art' instead of 'aelig.art'

**NOTE**

- I cannot replicate it on localhost, so let's try on production!
